### PR TITLE
DID URI Type, Routing Processes

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -282,8 +282,8 @@ These last two characteristics are the foundation of mix networking feature for 
 
 ### Sender Forward Process
 
-1. Sender Constructs Message
-2. Sender Encrypts Message to recipient(s)
+1. Sender Constructs Message.
+2. Sender Encrypts Message to recipient(s).
 3. Wrap Encrypted Message in Forward Message for each Routing Key.
 4. Transmit to `serviceEndpoint` in the manner specified in the [transports] section.
 
@@ -291,14 +291,14 @@ These last two characteristics are the foundation of mix networking feature for 
 
 _Prior to using a Mediator, it is the recipient's responsibility to coordinate with the mediator. Part of this coordination informs them of the `to` address(es) expected, the endpoint, and any Routing Keys to be used when forwarding messages. That coordination is out of the scope of this spec._
 
-1. Receives Forward Message
-2. Retrieves Service Endpoint and Routing Keys as pre-configured by recipient (`to` attribute).
-3. Wrap attached `payload` message once per Routing Key
+1. Receives Forward Message.
+2. Retrieves Service Endpoint and (optionally) Routing Keys as pre-configured by recipient (`to` attribute).
+3. If Routing Keys pre-configured (step 2), wrap attached `payload` message once per Routing Key.
 4. Transmit to Service Endpoint in the manner specified in the [transports] section.
 
 ### DID Document Keys
 
-All keys declared in the DID Document's `keyAgreement` section should be used to encrypt messages. The details of key representation are described in the [Public Keys section of the DID Core Spec](https://www.w3.org/TR/did-core/#public-keys).
+All keys declared in the DID Document's `keyAgreement` section should be used as recipients when encrypting a message. The details of key representation are described in the [Public Keys section of the DID Core Spec](https://www.w3.org/TR/did-core/#public-keys).
 
 Keys used in a signed JWM are declared in the DID Document's `authentication` section.
 
@@ -321,13 +321,13 @@ DIDComm DID Document endpoints have the following format:
 
 **type**: MUST be `DIDComm`. 
 
-**serviceEndpoint**: MUST contain a URI for a transport specified in the [transports] section of this spec, or a URI from Alternative Endpoints. Endpoints from the [transports] section SHOULD be used only for the reception of DIDComm messages.
+**serviceEndpoint**: MUST contain a URI for a transport specified in the [transports] section of this spec, or a URI from Alternative Endpoints. It MAY be desirable to constraint endpoints from the [transports] section so that they are used only for the reception of DIDComm messages. This can be particularly helpful in cases where auto-detecting message types is inefficient or undesirable.
 
 **routingKeys**: An optional ordered array of strings referencing keys to be used when preparing the message for transmission as specified in the [Routing] section of this spec. 
 
 #### Multiple Endpoints
 
-A DID Document may contain multiple service entries of type `DIDComm`. Unless otherwise specified, messages should be sent to endpoints in the order they are specified.
+A DID Document may contain multiple service entries of type `DIDComm`. Entries are SHOULD be specified in order of receiver preference, but any endpoint MAY be selected by the sender, typically by protocol availability or preference.
 
 #### Alternative Endpoints
 

--- a/routing.md
+++ b/routing.md
@@ -295,7 +295,7 @@ _Prior to using a Mediator, it is the recipient's responsibility to coordinate w
 2. Retrieves Service Endpoint pre-configured by recipient (`to` attribute).
 4. Transmit `payload` message to Service Endpoint in the manner specified in the [transports] section.
 
-The recipient (`to` attribute of Forward Message) may have pre-configured additional routing keys with the mediator. If this is the case, the mediator should wrap the attached `payload` message into an additional Forward message once per routing key. This step is performed between (2) and (3).
+The recipient (`to` attribute of Forward Message) may have pre-configured additional routing keys with the mediator that were not present in the DID Document and therefore unknown to the original sender. If this is the case, the mediator should wrap the attached `payload` message into an additional Forward message once per routing key. This step is performed between (2) and (3).
 
 ### DID Document Keys
 

--- a/routing.md
+++ b/routing.md
@@ -337,7 +337,7 @@ In addition to the URIs for [transports], some alternative forms are available.
 
 Using a DID for the `serviceEndpoint` is useful when using a mediator. The DID should be resolved, and services with type of "DIDComm" will contain valid `serviceEndpoints`. The keyAgreement keys of that DID Document should be appended at the end of the routingKeys section from the message recipient's DID Document as per the process in [Sender Forward Process]. The key advantage with this approach is that a mediator can rotate keys and update serviceEndpoints without any updates needed to dependent recipients` DID Documents.
 
-A DID used as a mediator in this way SHOULD NOT use alternative endpoints. Only URIs described in [transports] are should be used to avoid recursive lookups.
+A DID representing a mediator SHOULD NOT use alternative endpoints in it's own DID Document to avoid recursive endpoint resolution. Using only the URIs described in [transports] will prevent such recursion.
 
 Example 1: Mediator
 

--- a/routing.md
+++ b/routing.md
@@ -292,9 +292,10 @@ These last two characteristics are the foundation of mix networking feature for 
 _Prior to using a Mediator, it is the recipient's responsibility to coordinate with the mediator. Part of this coordination informs them of the `to` address(es) expected, the endpoint, and any Routing Keys to be used when forwarding messages. That coordination is out of the scope of this spec._
 
 1. Receives Forward Message.
-2. Retrieves Service Endpoint and (optionally) Routing Keys as pre-configured by recipient (`to` attribute).
-3. If Routing Keys pre-configured (step 2), wrap attached `payload` message once per Routing Key.
-4. Transmit to Service Endpoint in the manner specified in the [transports] section.
+2. Retrieves Service Endpoint pre-configured by recipient (`to` attribute).
+4. Transmit `payload` message to Service Endpoint in the manner specified in the [transports] section.
+
+The recipient (`to` attribute of Forward Message) may have pre-configured additional routing keys with the mediator. If this is the case, the mediator should wrap the attached `payload` message into an additional Forward message once per routing key. This step is performed between (2) and (3).
 
 ### DID Document Keys
 

--- a/routing.md
+++ b/routing.md
@@ -321,7 +321,7 @@ DIDComm DID Document endpoints have the following format:
 
 **type**: MUST be `DIDComm`. 
 
-**serviceEndpoint**: MUST contain a URI for a transport specified in the [transports] section of this spec, or a URI from Alternative Endpoints.
+**serviceEndpoint**: MUST contain a URI for a transport specified in the [transports] section of this spec, or a URI from Alternative Endpoints. Endpoints from the [transports] section SHOULD be used only for the reception of DIDComm messages.
 
 **routingKeys**: An optional ordered array of strings referencing keys to be used when preparing the message for transmission as specified in the [Routing] section of this spec. 
 
@@ -337,7 +337,7 @@ In addition to the URIs for [transports], some alternative forms are available.
 
 Using a DID for the `serviceEndpoint` is useful when using a mediator. The DID should be resolved, and services with type of "DIDComm" will contain valid `serviceEndpoints`. The keyAgreement keys of that DID Document should be appended at the end of the routingKeys section from the message recipient's DID Document as per the process in [Sender Forward Process]. The key advantage with this approach is that a mediator can rotate keys and update serviceEndpoints without any updates needed to dependent recipients` DID Documents.
 
-A DID used as a mediator in this way MUST NOT use alternative endpoints. Only URIs described in [transports] are acceptable.
+A DID used as a mediator in this way SHOULD NOT use alternative endpoints. Only URIs described in [transports] are should be used to avoid recursive lookups.
 
 Example 1: Mediator
 


### PR DESCRIPTION
This PR contains (initially, anyway) two related topics: The process followed by both senders and mediators that supports routing, and the use of a DID alternative URI type for dereferencing mediator endpoints and keys.

Signed-off-by: Sam Curren <telegramsam@gmail.com>