### PR TITLE
Remove Queue and ephemeral references

### DIFF
--- a/routing.md
+++ b/routing.md
@@ -164,11 +164,3 @@ Example 2: Mediator + Routing Keys
 ```
 
 The message is encrypted to the recipient, then wrapped in a forward message encrypted to `did:example:anothermediator#somekey`. That forward message is wrapped in a forward message encrypted to keyAgreement keys within the `did:example:somemediator` DID Document, and transmitted to the URIs present in the `did:example:somemediator` DID Document with type `DIDComm`.
-
-##### Queue
-
-TODO: Does the queue fit here as an alternate URI?
-
-
-
-[TODO: discuss how routing info is exposed in a DID doc, and how it is conveyed in "ephemeral mode" where no DID doc is available.]


### PR DESCRIPTION
Queue information is now present in the guide (as it relates to return-route), and the ephemeral mode is no longer a thing. I believe the correct answer is to remove these TODOs.
Signed-off-by: Sam Curren <telegramsam@gmail.com>