### PR TITLE
fix: removed (moved to didcomm.org) context files

### DIFF
--- a/docs/contexts/v2/index.json
+++ b/docs/contexts/v2/index.json
@@ -1,7 +1,0 @@
-{
-  "@context": {
-      "@version": 1.1,
-      "@protected": true,
-      "DIDCommMessaging": "https://didcomm.org/context/messaging/v2/#DIDCommMessaging"
-  }
-}


### PR DESCRIPTION
Removed context files since contexts files will be hosted in didcomm.org repo. see didcomm.org/messaging/contexts/v2