### PR TITLE
fixes #165 - updated typ/cty language for JWS/JWE/Plain

### DIFF
--- a/docs/spec-files/encryption.md
+++ b/docs/spec-files/encryption.md
@@ -46,12 +46,6 @@ TODO: Include language about safe nonce considerations.
 | ECDH-1PU+A256KW | P-521           | EC                 | ECDH-1PU key wrapping using key with NIST defined P-521 elliptic curve to create a 256 bits key as defined in [ecdh-1pu](https://tools.ietf.org/html/draft-madden-jose-ecdh-1pu-04#section-2) |
 | ECDH-1PU+A256KW | X25519          | OKP                | ECDH-1PU X25519 ([RFC7748 section 5](https://tools.ietf.org/html/rfc7748#section-5)) to create a 256 bits key as defined in [ecdh-1pu](https://tools.ietf.org/html/draft-madden-jose-ecdh-1pu-04#section-2) |
 
-## Media Types
-
-The media type of the envelope MUST be set in the `typ` [property](https://tools.ietf.org/html/rfc7516#section-4.1.11) of the JWE and the media type of the payload MUST be set in the `cty` [property](https://tools.ietf.org/html/rfc7516#section-4.1.12) of the JWE. The [message types](#message-types) section provides general discussion of the media types.
-
-For example, following the guidelines of [message types](#message-types), an encrypted envelope with a plaintext DIDComm payload contains the `typ` property with the value `application/didcomm-encrypted+json` and `cty` property with the value `application/didcomm-plain+json`.
-
 ## Perfect Forward Secrecy
 
 Due to the triple Key Derivation algorithm used in ECDH-1PU, all messages sent via DIDComm have weak perfect forward secrecy without any additional security added by the transport layer. In ECDH-1PU this is achieved by encrypting the content encryption key with the output of the hash of the Ze (ECDH of ephemeral key and recipient static key) and Zs (ECDH of static sender key and recipient static key). With Ze bringing the changed derived secret in each message and Zs bringing the repudiable authenticity of each message, the resulting Z (hash of Ze and Zs) carries the properties of weak perfect forward secrecy and repudiable authenticity for each message as well.

--- a/docs/spec-files/message_structure.md
+++ b/docs/spec-files/message_structure.md
@@ -112,7 +112,7 @@ The following example shows common elements of a plaintext message. Further deta
 
 The predefined attributes of a DIDComm plaintext message at the level of its outer packaging (effectively, the "headers" of the message) are as follows:
 
-- **typ** - REQUIRED. Media type of the JWM content and MUST be set to `application/didcomm-plain+json`.
+- **typ** - OPTIONAL. Media type of the JWM content and MUST be set to `application/didcomm-plain+json` for **DIDComm plaintext messages**.
 
 - **id** - REQUIRED. Message ID. The `id` attribute value MUST be unique to the sender.
 

--- a/docs/spec-files/message_structure.md
+++ b/docs/spec-files/message_structure.md
@@ -193,7 +193,7 @@ The JWT is constructed as follows, with appropriate values changed.
 
 ```json
 {
-    "typ": "application/didcomm-plain-json",
+    "typ": "application/didcomm-plain+json",
     "id": "1234567890",
     "type": "<message-type-uri>",
     "from": "did:example:alice2",

--- a/docs/spec-files/message_structure.md
+++ b/docs/spec-files/message_structure.md
@@ -30,7 +30,7 @@ When a message is *both* signed and encrypted, the plaintext is signed, and then
 
 The [media type](https://tools.ietf.org/html/rfc6838) of a DIDComm signed message MUST be `application/didcomm-signed+json`.
 
-The media type of the envelope MUST be set in the `typ` [property](https://tools.ietf.org/html/rfc7515#section-4.1.9) of the JWS and the media type of the payload MUST be set in the `cty` [property](https://tools.ietf.org/html/rfc7515#section-4.1.10) of the JWS.
+The media type of the envelope MUST be set in the `typ` [property](https://tools.ietf.org/html/rfc7515#section-4.1.9) of the JWS.
 
 When persisted as a file or attached as a payload in other contexts, the file extension for DIDComm signed messages SHOULD be `dcsm`, giving a globbing pattern of `*.dcsm`; this SHOULD be be read as "Star Dot D C S M" or as "D C S M" files. A possible icon for this media type depicts a signed envelope ([svg](../collateral/dcsm.svg) | [256x256](../collateral/dcsm-256.png) | [128x128](../collateral/dcsm-128.png) | [64x64](../collateral/dcsm-64.png)):
 
@@ -44,7 +44,7 @@ A **DIDComm encrypted message** is an encrypted [JWM (JSON Web Messages)](https:
 
 >Note: If future versions of this spec allow binary encodings, variations like `application/didcomm-encrypted+cbor` (see [CBOR RFC 7049, section 7.5](https://tools.ietf.org/html/rfc7049#section-7.5)), `application/didcomm-encrypted+msgpack`, or `application/didcomm-encrypted+protobuf` may become reasonable. Future DIDComm specs that encompass comm patterns other than messaging &mdash; DIDComm multicast or DIDComm streaming, for example &mdash; might use a suffix: `application/didcomm-encrypted-multicast` or similar.
 
-The media type of the envelope MUST be set in the `typ` [property](https://tools.ietf.org/html/rfc7516#section-4.1.11) of the JWE and the media type of the payload MUST be set in the `cty` [property](https://tools.ietf.org/html/rfc7516#section-4.1.12) of the JWE. Note, if the JWE wraps another JWE, according to [JWM (JSON Web Messages)](https://tools.ietf.org/html/draft-looker-jwm-01) the use of `application/JWM` for `cty` [property](https://tools.ietf.org/html/rfc7516#section-4.1.12) is mandated.
+The media type of the envelope MUST be set in the `typ` [property](https://tools.ietf.org/html/rfc7516#section-4.1.11) of the JWE.
 
 When persisted as a file or attached as a payload in other contexts, the file extension for DIDComm encrypted messages SHOULD be `dcem`, giving a globbing pattern of `*.dcem`; this SHOULD be be read as "Star Dot D C E M" or as "D C E M" files. A possible icon for this file format depicts an envelope with binary overlay, protected by a lock ([svg](../collateral/dcem.svg) | [256x256](../collateral/dcem-256.png) | [128x128](../collateral/dcem-128.png) | [64x64](../collateral/dcem-64.png)):
 
@@ -55,13 +55,13 @@ When persisted as a file or attached as a payload in other contexts, the file ex
 The following table provides an overview of examples for using the media type properties in various 
 DIDComm messages:
 
-| DIDComm message | `typ` | `cty` |
-|-----------------|-------|-------|
-| Encrypted | `application/didcomm-encrypted+json`| `application/didcomm-plain+json`|
-| Signed, then encrypted | `application/didcomm-encrypted+json`| `application/JWM` |
-| Encrypted, then encrypted | `application/didcomm-encrypted+json` | `application/JWM` |
-| Signed | `application/didcomm-signed+json` | `application/didcomm-plain+json`|
-| Plaintext | `application/didcomm-plain+json`| -
+| DIDComm message | `typ` |
+|-----------------|-------|
+| Encrypted | `application/didcomm-encrypted+json`|
+| Signed, then encrypted | `application/didcomm-encrypted+json`|
+| Encrypted, then encrypted | `application/didcomm-encrypted+json` |
+| Signed | `application/didcomm-signed+json` |
+| Plaintext | `application/didcomm-plain+json`|
 
 ## Negotiating Compatibility
 

--- a/docs/spec-files/out_of_band.md
+++ b/docs/spec-files/out_of_band.md
@@ -26,8 +26,9 @@ The out-of-band protocol a single message that is sent by the *sender*.
 
 ```jsonc
 {
-  "@type": "https://didcomm.org/out-of-band/%VER/invitation",
-  "@id": "<id used for context as pthid>",
+  "typ": "application/didcomm-plain+json",
+  "type": "https://didcomm.org/out-of-band/%VER/invitation",
+  "id": "<id used for context as pthid>",
   "goal_code": "issue-vc",
   "goal": "To issue a Faber College Graduate credential",
   "accept": [
@@ -48,8 +49,8 @@ The out-of-band protocol a single message that is sent by the *sender*.
 
 The items in the message are:
 
-- `@type` - the DIDComm message type
-- `@id` - the unique ID of the message. The ID should be used as the **parent** thread ID (`pthid`) for the response message, rather than the more common thread ID (`thid`) of the response message. This enables multiple uses of a single out-of-band message.
+- `type` - the DIDComm message type
+- `id` - the unique ID of the message. The ID should be used as the **parent** thread ID (`pthid`) for the response message, rather than the more common thread ID (`thid`) of the response message. This enables multiple uses of a single out-of-band message.
 - `goal_code` - [optional] a self-attested code the receiver may want to display to the user or use in automatically deciding what to do with the out-of-band message.
 - `goal` - [optional] a self-attested string that the receiver may want to display to the user about the context-specific goal of the out-of-band message.
 - `accept` - [optional] an array of media (aka mime) types in the order of preference of the sender that the receiver can use in responding to the message.
@@ -92,6 +93,7 @@ Invitation:
 
 ```json
 {
+  "typ": "application/didcomm-plain+json",
   "type": "https://didcomm.org/out-of-band/0.1/invitation",
   "id": "69212a3a-d068-4f9d-a2dd-4741bca89af3",
   "from": "did:example:alice",
@@ -114,19 +116,19 @@ Invitation:
 Whitespace removed:
 
 ```json
-{"type":"https://didcomm.org/out-of-band/0.1/invitation","id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","from":"did:example:alice","body":{"goal_code":"","goal": "","attachments":[{"@id":"request-0","mime-type":"application/json","data":{"json":"<json of protocol message>"}}]}}
+{"typ": "application/didcomm-plain+json","type":"https://didcomm.org/out-of-band/0.1/invitation","id":"69212a3a-d068-4f9d-a2dd-4741bca89af3","from":"did:example:alice","body":{"goal_code":"","goal": "","request~attach":[{"@id":"request-0","mime-type":"application/json","data":{"json":"<json of protocol message>"}}]}}
 ```
 
 Base 64 URL Encoded:
 
 ```text
-eyJ0eXBlIjoiaHR0cHM6Ly9kaWRjb21tLm9yZy9vdXQtb2YtYmFuZC8wLjEvaW52aXRhdGlvbiIsImlkIjoiNjkyMTJhM2EtZDA2OC00ZjlkLWEyZGQtNDc0MWJjYTg5YWYzIiwiZnJvbSI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYm9keSI6eyJnb2FsX2NvZGUiOiIiLCJnb2FsIjogIiIsInJlcXVlc3R-YXR0YWNoIjpbeyJAaWQiOiJyZXF1ZXN0LTAiLCJtaW1lLXR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwiZGF0YSI6eyJqc29uIjoiPGpzb24gb2YgcHJvdG9jb2wgbWVzc2FnZT4ifX1dfX0=
+eyJ0eXAiOiAiYXBwbGljYXRpb24vZGlkY29tbS1wbGFpbitqc29uIiwidHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMC4xL2ludml0YXRpb24iLCJpZCI6IjY5MjEyYTNhLWQwNjgtNGY5ZC1hMmRkLTQ3NDFiY2E4OWFmMyIsImZyb20iOiJkaWQ6ZXhhbXBsZTphbGljZSIsImJvZHkiOnsiZ29hbF9jb2RlIjoiIiwiZ29hbCI6ICIiLCJyZXF1ZXN0fmF0dGFjaCI6W3siQGlkIjoicmVxdWVzdC0wIiwibWltZS10eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImRhdGEiOnsianNvbiI6Ijxqc29uIG9mIHByb3RvY29sIG1lc3NhZ2U-In19XX19
 ```
 
 Example URL:
 
 ```text
-http://example.com/path?_oob=eyJ0eXBlIjoiaHR0cHM6Ly9kaWRjb21tLm9yZy9vdXQtb2YtYmFuZC8wLjEvaW52aXRhdGlvbiIsImlkIjoiNjkyMTJhM2EtZDA2OC00ZjlkLWEyZGQtNDc0MWJjYTg5YWYzIiwiZnJvbSI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYm9keSI6eyJnb2FsX2NvZGUiOiIiLCJnb2FsIjogIiIsInJlcXVlc3R-YXR0YWNoIjpbeyJAaWQiOiJyZXF1ZXN0LTAiLCJtaW1lLXR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwiZGF0YSI6eyJqc29uIjoiPGpzb24gb2YgcHJvdG9jb2wgbWVzc2FnZT4ifX1dfX0=
+http://example.com/path?_oob=eyJ0eXAiOiAiYXBwbGljYXRpb24vZGlkY29tbS1wbGFpbitqc29uIiwidHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMC4xL2ludml0YXRpb24iLCJpZCI6IjY5MjEyYTNhLWQwNjgtNGY5ZC1hMmRkLTQ3NDFiY2E4OWFmMyIsImZyb20iOiJkaWQ6ZXhhbXBsZTphbGljZSIsImJvZHkiOnsiZ29hbF9jb2RlIjoiIiwiZ29hbCI6ICIiLCJyZXF1ZXN0fmF0dGFjaCI6W3siQGlkIjoicmVxdWVzdC0wIiwibWltZS10eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImRhdGEiOnsianNvbiI6Ijxqc29uIG9mIHByb3RvY29sIG1lc3NhZ2U-In19XX19
 ```
 
 DIDComm message URLs can be transferred via any method that can send text, including an email, SMS, posting on a website, or QR Code.
@@ -140,9 +142,9 @@ Subject: Your request to connect and receive your graduate verifiable credential
 
 Dear Alice,
 
-To receive your Faber College graduation certificate, click here to [connect](http://example.com/path?_oob=eyJ0eXBlIjoiaHR0cHM6Ly9kaWRjb21tLm9yZy9vdXQtb2YtYmFuZC8wLjEvaW52aXRhdGlvbiIsImlkIjoiNjkyMTJhM2EtZDA2OC00ZjlkLWEyZGQtNDc0MWJjYTg5YWYzIiwiZnJvbSI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYm9keSI6eyJnb2FsX2NvZGUiOiIiLCJnb2FsIjogIiIsInJlcXVlc3R-YXR0YWNoIjpbeyJAaWQiOiJyZXF1ZXN0LTAiLCJtaW1lLXR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwiZGF0YSI6eyJqc29uIjoiPGpzb24gb2YgcHJvdG9jb2wgbWVzc2FnZT4ifX1dfX0= with us, or paste the following into your browser:
+To receive your Faber College graduation certificate, click here to [connect](http://example.com/path?_oob=eyJ0eXAiOiAiYXBwbGljYXRpb24vZGlkY29tbS1wbGFpbitqc29uIiwidHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMC4xL2ludml0YXRpb24iLCJpZCI6IjY5MjEyYTNhLWQwNjgtNGY5ZC1hMmRkLTQ3NDFiY2E4OWFmMyIsImZyb20iOiJkaWQ6ZXhhbXBsZTphbGljZSIsImJvZHkiOnsiZ29hbF9jb2RlIjoiIiwiZ29hbCI6ICIiLCJyZXF1ZXN0fmF0dGFjaCI6W3siQGlkIjoicmVxdWVzdC0wIiwibWltZS10eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImRhdGEiOnsianNvbiI6Ijxqc29uIG9mIHByb3RvY29sIG1lc3NhZ2U-In19XX19 with us, or paste the following into your browser:
 
-http://example.com/path?_oob=eyJ0eXBlIjoiaHR0cHM6Ly9kaWRjb21tLm9yZy9vdXQtb2YtYmFuZC8wLjEvaW52aXRhdGlvbiIsImlkIjoiNjkyMTJhM2EtZDA2OC00ZjlkLWEyZGQtNDc0MWJjYTg5YWYzIiwiZnJvbSI6ImRpZDpleGFtcGxlOmFsaWNlIiwiYm9keSI6eyJnb2FsX2NvZGUiOiIiLCJnb2FsIjogIiIsInJlcXVlc3R-YXR0YWNoIjpbeyJAaWQiOiJyZXF1ZXN0LTAiLCJtaW1lLXR5cGUiOiJhcHBsaWNhdGlvbi9qc29uIiwiZGF0YSI6eyJqc29uIjoiPGpzb24gb2YgcHJvdG9jb2wgbWVzc2FnZT4ifX1dfX0=
+http://example.com/path?_oob=eyJ0eXAiOiAiYXBwbGljYXRpb24vZGlkY29tbS1wbGFpbitqc29uIiwidHlwZSI6Imh0dHBzOi8vZGlkY29tbS5vcmcvb3V0LW9mLWJhbmQvMC4xL2ludml0YXRpb24iLCJpZCI6IjY5MjEyYTNhLWQwNjgtNGY5ZC1hMmRkLTQ3NDFiY2E4OWFmMyIsImZyb20iOiJkaWQ6ZXhhbXBsZTphbGljZSIsImJvZHkiOnsiZ29hbF9jb2RlIjoiIiwiZ29hbCI6ICIiLCJyZXF1ZXN0fmF0dGFjaCI6W3siQGlkIjoicmVxdWVzdC0wIiwibWltZS10eXBlIjoiYXBwbGljYXRpb24vanNvbiIsImRhdGEiOnsianNvbiI6Ijxqc29uIG9mIHByb3RvY29sIG1lc3NhZ2U-In19XX19
 
 If you don't have an identity agent for holding credentials, you will be given instructions on how you can get one.
 

--- a/docs/spec-files/transports.md
+++ b/docs/spec-files/transports.md
@@ -12,7 +12,7 @@ DIDComm Transports serve only as message _delivery_. No information about the ef
 HTTP(S) transports are an effective way to send a message to another online agent.
 
 - Messages are transported via HTTP POST.
-- The MIME Type for the POST request is `application/didcomm-encrypted+json`. See [Message Types](#message-types) for a general discussion of mime types.
+- The MIME Type for the POST request is set to the corresponding media type defined in [Media Types](#media-types), e.g., `application/didcomm-encrypted+json`.
 - A successful message receipt MUST return a code in the 2xx HTTP Status Code range. It is recommended that a HTTP POST should return a 202 Accepted status code. 
 - POST requests are transmit only. Messages are only sent from the code that submitted the POST request.
 - HTTP Redirects SHOULD be followed. Only Temporary Redirects (307) are acceptable. Permanent endpoint relocation should be managed with a DID Document update.


### PR DESCRIPTION
Potentially fixes #165 

* removed `typ` from encryption.md (seemed redundant).
* added explicit language that JWE/JWS are JWM.
* added `typ` as mandatory header for didcomm plaintext messages. 
* made `didcomm-signed+json`/`didcomm-encrypted+json` mandatory for JWE/JWS for `typ` property.
* updated and fixed OOB examples.

Overview (updated - including resolution from DIDComm WG meeting June 21st; removed language on `cty` which might need a separate issue if still required):

| DIDComm message | `typ` |
|-----------------|-------|
| Encrypted | `application/didcomm-encrypted+json`|
| Signed, then encrypted | `application/didcomm-encrypted+json`|
| Encrypted, then encrypted | `application/didcomm-encrypted+json` |
| Signed | `application/didcomm-signed+json` |
| Plaintext | `application/didcomm-plain+json`|
