### PR TITLE
Make from required

### DIFF
--- a/docs/spec-files/message_structure.md
+++ b/docs/spec-files/message_structure.md
@@ -103,7 +103,7 @@ Headers in DIDComm are intended to be extensible in much the same way that heade
 
 The `to` header cannot be used for routing, since it is encrypted at every intermediate point in a route. Instead, the `forward` message contains a `next` attribute in its body that specifies the target for the next routing operation.
 
-- **from** - OPTIONAL. Sender identifier. The `from` attribute MUST be a string that is a valid DID or [DID URL](https://w3c.github.io/did-core/#did-url-syntax) (without the [fragment component](https://w3c.github.io/did-core/#fragment)) which identifies the sender of the message. When a message is encrypted, the sender key MUST be authorized for encryption by this DID. Authorization of the encryption key for this DID MUST be verified by message recipient with the proper proof purposes. See the [message authentication](#Message-Authentication) section for additional details.
+- **from** - REQUIRED. Sender identifier. The `from` attribute MUST be a string that is a valid DID or [DID URL](https://w3c.github.io/did-core/#did-url-syntax) (without the [fragment component](https://w3c.github.io/did-core/#fragment)) which identifies the sender of the message. When a message is encrypted, the sender key MUST be authorized for encryption by this DID. Authorization of the encryption key for this DID MUST be verified by message recipient with the proper proof purposes. See the [message authentication](#Message-Authentication) section for additional details.
 
   When the sender wishes to be anonymous, they should use a new DID created for the purpose to avoid correlation with any other behavior or identity. Peer DIDs are lightweight and require no ledger writes, and therefore a good method to use for this purpose.
 


### PR DESCRIPTION
Signed-off-by: Sam Curren <telegramsam@gmail.com>

In #115 we discussed making anoncrypt not a thing, using disposable DIDs instead. 
In #141 I added that clarification.

I believe the only reason for `from` being optional was for the use of anonymous messaging, which we are no longer directly including. The JWM spec declares it as optional, but it is perfectly acceptable for the use of JWM within DIDComm to impose additional constraints.

Making `from` a required attribute solves the issues brought up with trust ping, and is something I had imaged before but did not apply the full change of removing anoncrypt.