### PR TITLE
Revert prototol name to report-problem and increase version

### DIFF
--- a/docs/spec-files/problems.md
+++ b/docs/spec-files/problems.md
@@ -30,7 +30,7 @@ Other entities are notified of problems by sending a simple message called a **p
 
 ```json
 {
-  "type": "https://didcomm.org/notify/1.0/problem-report",
+  "type": "https://didcomm.org/report-problem/2.0/problem-report",
   "id": "7c9de639-c51c-4d60-ab95-103fa613c805",
   "pthid": "1e513ad4-48c9-444e-9e7e-5b8b45c5e325",
   "body": {


### PR DESCRIPTION
This PR reverts the protocol name for the problem-report message in the spec. It was changed to `report-problem` to `notify` in the jump from v1, and this changes it back. The vision behind the change was the possibility of other messages within the protocol. Placing the definition in the spec itself makes such future additions difficult. 

Signed-off-by: Sam Curren <telegramsam@gmail.com>