### PR TITLE
Adds 'unknown' qualifier to third parties

### DIFF
--- a/docs/spec-files/requirements.md
+++ b/docs/spec-files/requirements.md
@@ -3,7 +3,7 @@
 The [DIDComm Messaging](.) design attempts to be:
 
 1. **Secure** (tamper-proof; uses best-of-breed crypto; allows parties to talk both on and off the record.)
-2. **Private** (third parties can’t learn who’s communicating about what, when; lets sender be anonymous to recipient) 
+2. **Private** (unknown third parties can’t learn who’s communicating about what, when; lets sender be anonymous to recipient) 
 3. **Decentralized** (derives trust for encryption, signing, authn, and authz from control of [DIDs]((https://www.w3.org/TR/did-core/)) rather than oracles like CAs, IDPs, etc; usable at the edge)
 4. **Transport-agnostic** (usable over HTTPS 1.x and 2.0, WebSockets, BlueTooth, chat, push notifications, libp2p, AMQP, SMTP, NFC, sneakernet, snail mail; supports both simplex and duplex; works offline; doesn't assume client-server or synchronous or real-time; allows paired or n-wise or public broadcast usage)
 5. **Routable** (like email, Alice can talk to Bob without a direct connection to Bob; allows mixed and dynamic transports; passes through mix networks and other generic infrastructure that sees only payload BLOBs)

--- a/docs/spec-files/requirements.md
+++ b/docs/spec-files/requirements.md
@@ -3,7 +3,7 @@
 The [DIDComm Messaging](.) design attempts to be:
 
 1. **Secure** (tamper-proof; uses best-of-breed crypto; allows parties to talk both on and off the record.)
-2. **Private** (unknown third parties can’t learn who’s communicating about what, when; lets sender be anonymous to recipient) 
+2. **Private** (unauthorized third parties can’t learn who’s communicating about what, when; lets sender be anonymous to recipient) 
 3. **Decentralized** (derives trust for encryption, signing, authn, and authz from control of [DIDs]((https://www.w3.org/TR/did-core/)) rather than oracles like CAs, IDPs, etc; usable at the edge)
 4. **Transport-agnostic** (usable over HTTPS 1.x and 2.0, WebSockets, BlueTooth, chat, push notifications, libp2p, AMQP, SMTP, NFC, sneakernet, snail mail; supports both simplex and duplex; works offline; doesn't assume client-server or synchronous or real-time; allows paired or n-wise or public broadcast usage)
 5. **Routable** (like email, Alice can talk to Bob without a direct connection to Bob; allows mixed and dynamic transports; passes through mix networks and other generic infrastructure that sees only payload BLOBs)


### PR DESCRIPTION
Intended to fix #10 by clarifying the difference between general 'third parties' and intentionally involved third parties such as mediators.

I'm not sure this is the right word clarification, but wanted to propose and get feedback.

Signed-off-by: Sam Curren <telegramsam@gmail.com>