### PR TITLE
fix https as transport over http

### DIFF
--- a/docs/spec-files/transports.md
+++ b/docs/spec-files/transports.md
@@ -13,20 +13,20 @@ Transports are defined within this section. Additional transports may be defined
 Each transport MUST define:
 
 - format of `serviceEndpoint` `uri`: Which URI schemes are used (if URI), or the properties of the object (if object).
-- how to actually send messages:  e.g., through HTTP POST, through dial protocol (libp2p), etc.
+- how to actually send messages:  e.g., through HTTPS POST, through dial protocol (libp2p), etc.
 - how mime-types of the content are provided, e.g., through Content-Type header, etc.
 - where additional context definition is hosted, e.g., in case the `serviceEndpoint`  object has extra properties specific to the transport.
 
 ### Reference
-#### HTTP(S)
+#### HTTPS
 
-HTTP(S) transports are an effective way to send a message to another online agent.
+HTTPS transports are an effective way to send a message to another online agent.
 
-- Messages are transported via HTTP POST.
+- Messages are transported via HTTPS POST.
 - The MIME Type for the POST request is set to the corresponding media type defined in [Media Types](#media-types), e.g., `application/didcomm-encrypted+json`.
-- A successful message receipt MUST return a code in the 2xx HTTP Status Code range. It is recommended that a HTTP POST should return a 202 Accepted status code. 
+- A successful message receipt MUST return a code in the 2xx HTTPS Status Code range. It is recommended that a HTTPS POST should return a 202 Accepted status code. 
 - POST requests are transmit only. Messages are only sent from the code that submitted the POST request.
-- HTTP Redirects SHOULD be followed. Only Temporary Redirects (307) are acceptable. Permanent endpoint relocation should be managed with a DID Document update.
+- HTTPS Redirects SHOULD be followed. Only Temporary Redirects (307) are acceptable. Permanent endpoint relocation should be managed with a DID Document update.
 - Using HTTPS with TLS 1.2 or greater with a forward secret cipher will provide Perfect Forward Secrecy (PFS) on the transmission leg.
 
 #### WebSocket
@@ -37,4 +37,4 @@ Websockets are an efficient way to transmit multiple messages without the overhe
 - The trust of each message comes from the Encryption Envelope, not the socket connection itself.
 - Websockets are considered transmit only. Messages flow only from the agent that opened the socket.
 - Using Secure Websockets (wss://) with TLS 1.2 or greater with a forward secret cipher will provide Perfect Forward Secrecy (PFS) on the transmission leg.
-- When using STOMP over WebSocket, the content-type header is application/didcomm-enc-env as in the HTTP(S) message.
+- When using STOMP over WebSocket, the content-type header is application/didcomm-enc-env as in the HTTPS message.


### PR DESCRIPTION
This acts as a companion to @mccown's adjustment to HTTPS for all examples. It fixes the requirement for HTTPS for transports. This addresses concerns about mobile agents and the exceptions mobile platforms are required to make if a regular HTTP connection is used. It also addresses the perception of HTTPS always being a best practice, even if in this case it results in double encryption.